### PR TITLE
Add ci-infra-dns-monitor-nodedns daemonset to use node DNS which uses SDN, but not CoreDNS

### DIFF
--- a/redeploy.sh
+++ b/redeploy.sh
@@ -13,6 +13,10 @@ for context in $@ ; do
   echo "Applying to context: ${context}"
   oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor
   oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor-hostnetwork
+  oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor-cluster-first
+  oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor-hostnetwork
+  oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor-hostnetwork-cluster-first
+  oc --as system:admin delete --context ${context} -n ci-infra-dns-monitor ds/ci-infra-dns-monitor-nodedns
   oc --as system:admin apply --context ${context} -f resources.yaml
 
   if ! oc --as system:admin get secrets --context ${context} -n ci-infra-dns-monitor openshift-gce-devel-kettle; then

--- a/resources.yaml
+++ b/resources.yaml
@@ -145,3 +145,62 @@ spec:
       - name: creds
         secret:
           secretName: openshift-gce-devel-kettle
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ci-infra-dns-monitor-nodedns
+  namespace: ci-infra-dns-monitor
+  labels:
+    k8s-app: ci-infra-dns-monitor-nodedns
+spec:
+  selector:
+    matchLabels:
+      name: ci-infra-dns-monitor-nodedns
+  template:
+    metadata:
+      labels:
+        name: ci-infra-dns-monitor-nodedns
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/ci-builds-worker
+        operator: Exists
+      - key: node-role.kubernetes.io/ci-tests-worker
+        operator: Exists
+      - key: node-role.kubernetes.io/ci-longtests-worker
+        operator: Exists
+      - key: node-role.kubernetes.io/ci-prowjobs-worker
+        operator: Exists
+      securityContext:
+        capabilities:
+          add:
+          - NET_RAW
+      dnsPolicy: Default
+      containers:
+      - name: dns-monitor
+        image: quay.io/jupierce/infra-dns-monitor:prod
+        imagePullPolicy: Always
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: TEST_VARIANT
+          value: "-nodedns"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /tmp/creds/openshift-gce-devel-kettle.json
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: creds
+          mountPath: "/tmp/creds"
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: creds
+        secret:
+          secretName: openshift-gce-devel-kettle


### PR DESCRIPTION
Remove cluster-first daemon sets and add a daemonset for node dns that uses `dnsPolicy: Default`.

This adds a test case in which SDN is used, but CoreDNS is not for DNS requests. Would be informative if it succeeds (CoreDNS problematic?) or fails (SDN problematic?).